### PR TITLE
Fixed MatchParameter for reference types

### DIFF
--- a/TomLonghurst.ILogger.UnitTest.Verifier.Moq.Tests/ParameterTests.cs
+++ b/TomLonghurst.ILogger.UnitTest.Verifier.Moq.Tests/ParameterTests.cs
@@ -22,7 +22,7 @@ public class ParameterTests
     [TestCase(1)]
     [TestCase("val")]
     [TestCase(true)]
-    public void Verify_Logger_Parameter(object value)
+    public void Verify_Logger_Parameter_By_Reference(object value)
     {
         _logger.LogInformation("Some message {Value}", value);
 
@@ -35,6 +35,30 @@ public class ParameterTests
                     Parameters = new []
                     {
                         new KeyValuePair<string, object>("Value", value),
+                    }
+                }
+            }
+        });
+    }
+
+    [TestCase(1, 1)]
+    [TestCase("val", "val")]
+    [TestCase(true, true)]
+    public void Verify_Logger_Parameter_By_Value(object loggedValue, object expectedValue)
+    {
+        _logger.LogInformation("Some message {Value}", loggedValue);
+        
+        Assert.That(loggedValue, Is.Not.SameAs(expectedValue));
+
+        _loggerMock.Verify(new LoggerVerifyOptions
+        {
+            MessageOptions =
+            {
+                MessageParametersOptions =
+                {
+                    Parameters = new []
+                    {
+                        new KeyValuePair<string, object>("Value", expectedValue),
                     }
                 }
             }

--- a/TomLonghurst.ILogger.UnitTest.Verifier.Moq/Helpers/MatchHelper.cs
+++ b/TomLonghurst.ILogger.UnitTest.Verifier.Moq/Helpers/MatchHelper.cs
@@ -30,7 +30,7 @@ internal static class MatchHelper
         foreach (var parameter in loggerVerifyOptions.MessageOptions.MessageParametersOptions.Parameters ?? Array.Empty<KeyValuePair<string, object>>())
         {
             var loggedValue = (values?.Where(x => x.Key == parameter.Key) ?? Array.Empty<KeyValuePair<string, object>>()).ToList();
-            if (!loggedValue.Any() || loggedValue.First().Value != parameter.Value)
+            if (!loggedValue.Any() || !loggedValue.First().Value.Equals(parameter.Value))
             {
                 return false;
             }


### PR DESCRIPTION
Fixed an issue where equality check for logged and expected parameter did not work for reference types